### PR TITLE
feat: set max lines for pane text views

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -25,3 +25,5 @@ var AnsiColor = struct {
 	Green: "\033[32m",
 	Reset: "\033[0m",
 }
+
+var MaxPaneOutputLines = 500

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -26,4 +26,8 @@ var AnsiColor = struct {
 	Reset: "\033[0m",
 }
 
+// MaxPaneOutputLines defines the maximum number of lines that can be displayed in a pane.
+// The limit of 500 was chosen to balance performance and usability:
+// - Performance: Rendering too many lines can degrade UI responsiveness.
+// - Usability: Limiting the output prevents overwhelming the user with excessive information.
 var MaxPaneOutputLines = 500

--- a/pkg/view/view.go
+++ b/pkg/view/view.go
@@ -243,7 +243,7 @@ func (v *View) getRootView(configPanes []config.ConfigPane) *tview.Pages {
 			SetScrollable(true).
 			SetChangedFunc(func() {
 				v.tviewApp.Draw()
-			}).ScrollToEnd()
+			}).ScrollToEnd().SetMaxLines(constant.MaxPaneOutputLines)
 		tv.
 			SetBorder(true).
 			SetTitle(getPaneTitle(index, configPane, tv.HasFocus()))


### PR DESCRIPTION
to prevent the slowness when the app is running pretty much long
