### PR TITLE
feat: intercept interrupt signal when the app is suspended

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.1
 require (
 	github.com/gdamore/tcell/v2 v2.8.1
 	github.com/goccy/go-yaml v1.17.1
-	github.com/rivo/tview v0.0.0-20250330220935-949945f8d922
+	github.com/rivo/tview v0.0.0-20250625164341-a4a78f1e05cb
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/rivo/tview v0.0.0-20250330220935-949945f8d922 h1:SMyqkaRfpE8ZQUSRTZKO3uN84xov++OGa+e3NCksaQw=
 github.com/rivo/tview v0.0.0-20250330220935-949945f8d922/go.mod h1:02iFIz7K/A9jGCvrizLPvoqr4cEIx7q54RH5Qudkrss=
+github.com/rivo/tview v0.0.0-20250625164341-a4a78f1e05cb h1:n7UJ8X9UnrTZBYXnd1kAIBc067SWyuPIrsocjketYW8=
+github.com/rivo/tview v0.0.0-20250625164341-a4a78f1e05cb/go.mod h1:cSfIYfhpSGCjp3r/ECJb+GKS7cGJnqV8vfjQPwoXyfY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/pkg/view/view.go
+++ b/pkg/view/view.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jiyeol-lee/localdev/pkg/constant"
 	"github.com/jiyeol-lee/localdev/pkg/util"
 	"github.com/rivo/tview"
+	"golang.org/x/sys/unix"
 )
 
 type Pane struct {
@@ -70,7 +71,7 @@ func sanitizeForDisplay(s string) string {
 func (v *View) runCustomUserCommand(dir string, userCmd string) {
 	v.tviewApp.Suspend(func() {
 		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT)
+		signal.Notify(sigCh, unix.SIGINT)
 		defer func() {
 			signal.Stop(sigCh)
 			close(sigCh)
@@ -88,7 +89,7 @@ func (v *View) runCustomUserCommand(dir string, userCmd string) {
 		cmd.Dir = dir
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		cmd.SysProcAttr = &unix.SysProcAttr{Setpgid: true}
 
 		// Sanitize the command for safe display
 		sanitizedCmd := sanitizeForDisplay(userCmd)
@@ -126,25 +127,38 @@ func (v *View) runCustomUserCommand(dir string, userCmd string) {
 			return
 		}
 
-		isCancelled := false
 		doneCh := make(chan error, 1)
 		go func() { doneCh <- cmd.Wait() }()
 	loop:
 		for {
 			select {
 			case err := <-doneCh:
-				if !isCancelled && err != nil {
+				// Check if process was killed by signal
+				if err != nil {
+					if cmd.ProcessState != nil {
+						if status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
+							// If killed by SIGKILL, suppress error message
+							if status.Signaled() && status.Signal() == unix.SIGKILL {
+								break loop
+							}
+						}
+					}
 					fmt.Printf("%sError running command: %s%s\n", constant.AnsiColor.Red, err, constant.AnsiColor.Reset)
 				}
 				break loop
 			case <-sigCh:
-				isCancelled = true
 				cancel()
+				// kill the process group to ensure all child processes are terminated
+				if cmd.Process != nil {
+					unix.Kill(-cmd.Process.Pid, unix.SIGKILL)
+				}
 			}
 		}
 
-		// Without this, all of the input from the user while the command is running will be passed to fmt.Scanln
-		// I do not know why this happens, but it does.
+		// When the external command is running, any keystrokes entered by the user are buffered by the terminal.
+		// After the command completes and control returns to the Go program, these buffered inputs are immediately consumed by fmt.Scanln,
+		// which can cause it to return without waiting for new user input. The flushInput() function clears any buffered input,
+		// ensuring that fmt.Scanln waits for fresh input from the user.
 		flushInput()
 
 		// Wait for user input after command completes
@@ -180,7 +194,7 @@ func (v *View) runPaneUserCommand(dir string, userCmd string, textView *tview.Te
 	}
 	cmd := exec.Command(shell, "-c", userCmd)
 	cmd.Dir = dir
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = &unix.SysProcAttr{Setpgid: true}
 
 	stdout, stdoutErr := cmd.StdoutPipe()
 	if stdoutErr != nil {


### PR DESCRIPTION
instead of killing the whole app if the interrupt signal is passed, we need to kill the current running process while the app is suspended and then go back to the app